### PR TITLE
Fixes to CCI

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -386,12 +386,28 @@
           "Title": "Permission for Journal Entries",
           "Hint": "When set to show set Document ownership to this level"
         },
+        "PermissionDocumentHide": {
+          "Title": "Hide Permission for Journal Entries",
+          "Hint": "When set to hide set Document ownership to this level"
+        },
         "PermissionPage": {
           "Title": "Permission for Journal Entry Pages",
           "Hint": "When set to show set Journal Entry Page ownership to this level"
         },
-        "RegionUuids": {
-          "Title": "Then trigger these CCI Regions on Right Click",
+        "PermissionPageHide": {
+          "Title": "Hide Permission for Journal Entry Pages",
+          "Hint": "When set to hide set Journal Entry Page ownership to this level"
+        },
+        "TriggerButton": {
+          "Title": "Trigger Region Button",
+          "Hint": "If Mouse Button is Both, and this button is used trigger the following region"
+        },
+        "TriggerRegionUuids": {
+          "Title": "Trigger This Region",
+          "Hint": ""
+        },
+        "TriggerAsButton": {
+          "Title": "With A Button Click",
           "Hint": ""
         }
       },
@@ -510,12 +526,28 @@
           "Title": "Permission for Journal Entries",
           "Hint": "When set to show set Document ownership to this level"
         },
+        "PermissionDocumentHide": {
+          "Title": "Hide Permission for Journal Entries",
+          "Hint": "When set to hide set Document ownership to this level"
+        },
         "PermissionPage": {
           "Title": "Permission for Journal Entry Pages",
           "Hint": "When set to show set Journal Entry Page ownership to this level"
         },
-        "RegionUuids": {
-          "Title": "Then trigger these CCI Regions on Right Click",
+        "PermissionPageHide": {
+          "Title": "Hide Permission for Journal Entry Pages",
+          "Hint": "When set to hide set Journal Entry Page ownership to this level"
+        },
+        "TriggerButton": {
+          "Title": "Trigger Region Button",
+          "Hint": "If Mouse Button is Both, and this button is used trigger the following region"
+        },
+        "TriggerRegionUuids": {
+          "Title": "Trigger This Region",
+          "Hint": ""
+        },
+        "TriggerAsButton": {
+          "Title": "With A Button Click",
           "Hint": ""
         }
       }

--- a/system/apps/CCI/drawing-toggle.mjs
+++ b/system/apps/CCI/drawing-toggle.mjs
@@ -66,6 +66,13 @@ export default class ChaosiumCanvasInterfaceDrawingToggle extends ChaosiumCanvas
         hint: 'ROL.ChaosiumCanvasInterface.DrawingToggle.PermissionDocument.Hint',
         required: true
       }),
+      permissionDocumentHide: new fields.NumberField({
+        choices: Object.keys(ChaosiumCanvasInterfaceDrawingToggle.PERMISSIONS).reduce((c, k) => { c[k] = game.i18n.localize(ChaosiumCanvasInterfaceDrawingToggle.PERMISSIONS[k]); return c }, {}),
+        initial: CONST.DOCUMENT_OWNERSHIP_LEVELS.NONE,
+        label: 'ROL.ChaosiumCanvasInterface.DrawingToggle.PermissionDocumentHide.Title',
+        hint: 'ROL.ChaosiumCanvasInterface.DrawingToggle.PermissionDocumentHide.Hint',
+        required: true
+      }),
       journalEntryPageUuids: new fields.SetField(
         new fields.DocumentUUIDField({
           type: 'JournalEntryPage'
@@ -82,6 +89,13 @@ export default class ChaosiumCanvasInterfaceDrawingToggle extends ChaosiumCanvas
         hint: 'ROL.ChaosiumCanvasInterface.DrawingToggle.PermissionPage.Hint',
         required: true
       }),
+      permissionPageHide: new fields.NumberField({
+        choices: Object.keys(ChaosiumCanvasInterfaceDrawingToggle.PERMISSIONS).reduce((c, k) => { c[k] = game.i18n.localize(ChaosiumCanvasInterfaceDrawingToggle.PERMISSIONS[k]); return c }, {}),
+        initial: CONST.DOCUMENT_OWNERSHIP_LEVELS.NONE,
+        label: 'ROL.ChaosiumCanvasInterface.DrawingToggle.PermissionPageHide.Title',
+        hint: 'ROL.ChaosiumCanvasInterface.DrawingToggle.PermissionPageHide.Hint',
+        required: true
+      }),
       regionBehaviorUuids: new fields.SetField(
         new fields.DocumentUUIDField({
           type: 'RegionBehavior'
@@ -91,21 +105,33 @@ export default class ChaosiumCanvasInterfaceDrawingToggle extends ChaosiumCanvas
           hint: 'ROL.ChaosiumCanvasInterface.DrawingToggle.RegionBehavior.Hint'
         }
       ),
+      regionButton: new fields.NumberField({
+        choices: ChaosiumCanvasInterface.triggerButtons,
+        initial: ChaosiumCanvasInterface.triggerButton.Right,
+        label: 'ROL.ChaosiumCanvasInterface.DrawingToggle.TriggerButton.Title',
+        hint: 'ROL.ChaosiumCanvasInterface.DrawingToggle.TriggerButton.Hint'
+      }),
       regionUuids: new fields.SetField(
         new fields.DocumentUUIDField({
           type: 'Region'
         }),
         {
-          label: 'ROL.ChaosiumCanvasInterface.DrawingToggle.RegionUuids.Title',
-          hint: 'ROL.ChaosiumCanvasInterface.DrawingToggle.RegionUuids.Hint'
+          label: 'ROL.ChaosiumCanvasInterface.DrawingToggle.TriggerRegionUuids.Title',
+          hint: 'ROL.ChaosiumCanvasInterface.DrawingToggle.TriggerRegionUuids.Hint'
         }
       ),
+      triggerAsButton: new fields.NumberField({
+        choices: ChaosiumCanvasInterface.triggerButtons,
+        initial: ChaosiumCanvasInterface.triggerButton.Left,
+        label: 'ROL.ChaosiumCanvasInterface.DrawingToggle.TriggerAsButton.Title',
+        hint: 'ROL.ChaosiumCanvasInterface.DrawingToggle.TriggerAsButton.Hint'
+      }),
     }
   }
 
   static migrateData (source) {
-    if (typeof source.triggerButton === 'undefined' && source.regionUuids.length) {
-      source.triggerButton = ChaosiumCanvasInterfaceTileToggle.triggerButton.Both
+    if (typeof source.triggerButton === 'undefined' && source.regionUuids?.length) {
+      source.triggerButton = ChaosiumCanvasInterfaceDrawingToggle.triggerButton.Both
     }
     return source
   }
@@ -123,8 +149,8 @@ export default class ChaosiumCanvasInterfaceDrawingToggle extends ChaosiumCanvas
         console.error('Drawing ' + uuid + ' not loaded')
       }
     }
-    const permissionDocument = (!this.toggle ? CONST.DOCUMENT_OWNERSHIP_LEVELS.NONE : this.permissionDocument)
-    const permissionPage = (!this.toggle ? CONST.DOCUMENT_OWNERSHIP_LEVELS.NONE : this.permissionPage)
+    const permissionDocument = (!this.toggle ? this.permissionDocumentHide : this.permissionDocument)
+    const permissionPage = (!this.toggle ? this.permissionPageHide : this.permissionPage)
     for (const uuid of this.journalEntryUuids) {
       const doc = await fromUuid(uuid)
       if (doc) {
@@ -149,13 +175,15 @@ export default class ChaosiumCanvasInterfaceDrawingToggle extends ChaosiumCanvas
         console.error('Region Behavior ' + uuid + ' not loaded')
       }
     }
-    if (this.triggerButton === ChaosiumCanvasInterfaceTileToggle.triggerButton.Both) {
+    if (this.triggerButton === ChaosiumCanvasInterfaceDrawingToggle.triggerButton.Both) {
       for (const uuid of this.regionUuids) {
         setTimeout(() => {
-          if (button === ChaosiumCanvasInterface.triggerButton.Right) {
-            game.rol.ClickRegionLeftUuid(uuid)
-          } else if (button === ChaosiumCanvasInterface.triggerButton.Left) {
-            game.rol.ClickRegionRightUuid(uuid)
+          if (button === this.regionButton) {
+            if (this.triggerAsButton === ChaosiumCanvasInterface.triggerButton.Right) {
+              game.rol.ClickRegionRightUuid(uuid)
+            } else if (this.triggerAsButton === ChaosiumCanvasInterface.triggerButton.Left) {
+              game.rol.ClickRegionLeftUuid(uuid)
+            }
           }
         }, 100)
       }

--- a/system/apps/CCI/tile-toggle.mjs
+++ b/system/apps/CCI/tile-toggle.mjs
@@ -66,6 +66,13 @@ export default class ChaosiumCanvasInterfaceTileToggle extends ChaosiumCanvasInt
         hint: 'ROL.ChaosiumCanvasInterface.TileToggle.PermissionDocument.Hint',
         required: true
       }),
+      permissionDocumentHide: new fields.NumberField({
+        choices: Object.keys(ChaosiumCanvasInterfaceTileToggle.PERMISSIONS).reduce((c, k) => { c[k] = game.i18n.localize(ChaosiumCanvasInterfaceTileToggle.PERMISSIONS[k]); return c }, {}),
+        initial: CONST.DOCUMENT_OWNERSHIP_LEVELS.NONE,
+        label: 'ROL.ChaosiumCanvasInterface.TileToggle.PermissionDocumentHide.Title',
+        hint: 'ROL.ChaosiumCanvasInterface.TileToggle.PermissionDocumentHide.Hint',
+        required: true
+      }),
       journalEntryPageUuids: new fields.SetField(
         new fields.DocumentUUIDField({
           type: 'JournalEntryPage'
@@ -82,6 +89,13 @@ export default class ChaosiumCanvasInterfaceTileToggle extends ChaosiumCanvasInt
         hint: 'ROL.ChaosiumCanvasInterface.TileToggle.PermissionPage.Hint',
         required: true
       }),
+      permissionPageHide: new fields.NumberField({
+        choices: Object.keys(ChaosiumCanvasInterfaceTileToggle.PERMISSIONS).reduce((c, k) => { c[k] = game.i18n.localize(ChaosiumCanvasInterfaceTileToggle.PERMISSIONS[k]); return c }, {}),
+        initial: CONST.DOCUMENT_OWNERSHIP_LEVELS.NONE,
+        label: 'ROL.ChaosiumCanvasInterface.TileToggle.PermissionPageHide.Title',
+        hint: 'ROL.ChaosiumCanvasInterface.TileToggle.PermissionPageHide.Hint',
+        required: true
+      }),
       regionBehaviorUuids: new fields.SetField(
         new fields.DocumentUUIDField({
           type: 'RegionBehavior'
@@ -91,20 +105,32 @@ export default class ChaosiumCanvasInterfaceTileToggle extends ChaosiumCanvasInt
           hint: 'ROL.ChaosiumCanvasInterface.TileToggle.RegionBehavior.Hint'
         }
       ),
+      regionButton: new fields.NumberField({
+        choices: ChaosiumCanvasInterface.triggerButtons,
+        initial: ChaosiumCanvasInterface.triggerButton.Right,
+        label: 'ROL.ChaosiumCanvasInterface.TileToggle.TriggerButton.Title',
+        hint: 'ROL.ChaosiumCanvasInterface.TileToggle.TriggerButton.Hint'
+      }),
       regionUuids: new fields.SetField(
         new fields.DocumentUUIDField({
           type: 'Region'
         }),
         {
-          label: 'ROL.ChaosiumCanvasInterface.TileToggle.RegionUuids.Title',
-          hint: 'ROL.ChaosiumCanvasInterface.TileToggle.RegionUuids.Hint'
+          label: 'ROL.ChaosiumCanvasInterface.TileToggle.TriggerRegionUuids.Title',
+          hint: 'ROL.ChaosiumCanvasInterface.TileToggle.TriggerRegionUuids.Hint'
         }
       ),
+      triggerAsButton: new fields.NumberField({
+        choices: ChaosiumCanvasInterface.triggerButtons,
+        initial: ChaosiumCanvasInterface.triggerButton.Left,
+        label: 'ROL.ChaosiumCanvasInterface.TileToggle.TriggerAsButton.Title',
+        hint: 'ROL.ChaosiumCanvasInterface.TileToggle.TriggerAsButton.Hint'
+      }),
     }
   }
 
   static migrateData (source) {
-    if (typeof source.triggerButton === 'undefined' && source.regionUuids.length) {
+    if (typeof source.triggerButton === 'undefined' && source.regionUuids?.length) {
       source.triggerButton = ChaosiumCanvasInterfaceTileToggle.triggerButton.Both
     }
     return source
@@ -123,8 +149,8 @@ export default class ChaosiumCanvasInterfaceTileToggle extends ChaosiumCanvasInt
         console.error('Tile ' + uuid + ' not loaded')
       }
     }
-    const permissionDocument = (!this.toggle ? CONST.DOCUMENT_OWNERSHIP_LEVELS.NONE : this.permissionDocument)
-    const permissionPage = (!this.toggle ? CONST.DOCUMENT_OWNERSHIP_LEVELS.NONE : this.permissionPage)
+    const permissionDocument = (!this.toggle ? this.permissionDocumentHide : this.permissionDocument)
+    const permissionPage = (!this.toggle ? this.permissionPageHide : this.permissionPage)
     for (const uuid of this.journalEntryUuids) {
       const doc = await fromUuid(uuid)
       if (doc) {
@@ -152,10 +178,12 @@ export default class ChaosiumCanvasInterfaceTileToggle extends ChaosiumCanvasInt
     if (this.triggerButton === ChaosiumCanvasInterfaceTileToggle.triggerButton.Both) {
       for (const uuid of this.regionUuids) {
         setTimeout(() => {
-          if (button === ChaosiumCanvasInterface.triggerButton.Right) {
-            game.rol.ClickRegionLeftUuid(uuid)
-          } else if (button === ChaosiumCanvasInterface.triggerButton.Left) {
-            game.rol.ClickRegionRightUuid(uuid)
+          if (button === this.regionButton) {
+            if (this.triggerAsButton === ChaosiumCanvasInterface.triggerButton.Right) {
+              game.rol.ClickRegionRightUuid(uuid)
+            } else if (this.triggerAsButton === ChaosiumCanvasInterface.triggerButton.Left) {
+              game.rol.ClickRegionLeftUuid(uuid)
+            }
           }
         }, 100)
       }


### PR DESCRIPTION
Fix error in Drawing CCI migrateData

Add hide permission to Drawing and Tile to prevent always using None

Rename ROL.ChaosiumCanvasInterface.TileToggle.RegionUuids.* and ROL.ChaosiumCanvasInterface.DrawingToggle.RegionUuids.* as this now functions differently
- Trigger Region Button [Left / Right]
- Trigger This Region [Region]
- With A Button Click [Left / Right]